### PR TITLE
Fixed 24H/12H time format due to unforced locale

### DIFF
--- a/CountdownLabel/CountdownLabel.swift
+++ b/CountdownLabel/CountdownLabel.swift
@@ -32,7 +32,7 @@ public class CountdownLabel: LTMorphingLabel {
     // conputed property
     public var dateFormatter: DateFormatter {
         let df = DateFormatter()
-        df.locale = NSLocale.current
+        df.locale = Locale(identifier: "en_US_POSIX")
         df.timeZone = NSTimeZone(name: "GMT") as TimeZone!
         df.dateFormat = timeFormat
         return df


### PR DESCRIPTION
When counting down with 12H time format, if counting down less than an hour it would appear as "12:05:00 AM" instead of "00:05:00", even forcing time format to "HH:mm:ss".

The time format was being ignored since the phone had an unconpatible locale with this time format. Using en_US_POSIX locale fixes this issue. 

Reference from: https://developer.apple.com/library/content/qa/qa1480/_index.html