### PR TITLE
Fix expression to remove type-check compiler error in Xcode 12.5

### DIFF
--- a/CountdownLabel/LTMorphingLabel/LTEasing.swift
+++ b/CountdownLabel/LTMorphingLabel/LTEasing.swift
@@ -17,15 +17,15 @@ import Foundation
 public struct LTEasing {
     
     public static func easeOutQuint(_ t: Float, _ b: Float, _ c: Float, _ d: Float = 1.0) -> Float {
-        return {
-            return c * ($0 * $0 * $0 * $0 * $0 + 1.0) + b
-            }(t / d - 1.0)
+        return { (f: Float) in
+            return c * (pow(f, 5) + 1.0) + b
+        }(t / d - 1.0)
     }
     
     public static func easeInQuint(_ t: Float, _ b: Float, _ c: Float, _ d: Float = 1.0) -> Float {
-        return {
-            return c * $0 * $0 * $0 * $0 * $0 + b
-            }(t / d)
+        return { (f: Float) in
+            c * pow(f, 5) + b
+        }(t / d)
     }
     
     public static func easeOutBack(_ t: Float, _ b: Float, _ c: Float, _ d: Float = 1.0) -> Float {
@@ -35,17 +35,17 @@ public struct LTEasing {
     }
     
     public static func easeOutBounce(_ t: Float, _ b: Float, _ c: Float, _ d: Float = 1.0) -> Float {
-        return {
-            if $0 < 1 / 2.75 {
-                return c * 7.5625 * $0 * $0 + b
-            } else if $0 < 2 / 2.75 {
-                let t = $0 - 1.5 / 2.75
+        return { (f: Float) in
+            if f < 1 / 2.75 {
+                return c * 7.5625 * f * f + b
+            } else if f < 2 / 2.75 {
+                let t = f - 1.5 / 2.75
                 return c * (7.5625 * t * t + 0.75) + b
-            } else if $0 < 2.5 / 2.75 {
-                let t = $0 - 2.25 / 2.75
+            } else if f < 2.5 / 2.75 {
+                let t = f - 2.25 / 2.75
                 return c * (7.5625 * t * t + 0.9375) + b
             } else {
-                let t = $0 - 2.625 / 2.75
+                let t = f - 2.625 / 2.75
                 return c * (7.5625 * t * t + 0.984375) + b
             }
         }(t / d)


### PR DESCRIPTION
**Issue**

This issue is getting after Xcode 12 update.

The issue is caused by the expression which needed to be break down into sub-expressions

Using release version : 4.0.1

`The compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions`

**Proposed solution** 

Replacing expression:
      

```
  return {
        return c * ($0 * $0 * $0 * $0 * $0 + 1.0) + b
  }(t / d - 1.0)
```

with

```
   return { (f: Float) in
            return c * (pow(f, 5) + 1.0) + b
    }(t / d - 1.0)
```
